### PR TITLE
remove share from record

### DIFF
--- a/commands/record.js
+++ b/commands/record.js
@@ -158,11 +158,7 @@ function done() {
   process.stdin.removeAllListeners();
   process.stdin.setRawMode(false);
   process.stdin.pause();
-
-  // Invoke the share command
-  di.commands.share.handler({
-    recordingFile: recordingFile
-  });
+  process.exit();
 
 }
 


### PR DESCRIPTION
This tool is amazing!

In trying to automate a record workflow, calling the share command afterward seemed intrusive to the workflow. When I discovered that you could share anytime with the separate share command, I thought that maybe this functionality was better off being removed from record's done function. 

Happy to explore other options like adding a flag `--share` to the record command if we think there's still a use case for that.

Closes https://github.com/faressoft/terminalizer/issues/69