### PR TITLE
Allow to disable hardware acceleration in electron for systems without GPU support

### DIFF
--- a/render/index.js
+++ b/render/index.js
@@ -11,6 +11,15 @@ var path          = require('path'),
     ipcMain       = require('electron').ipcMain,
     os            = require('os');
 
+
+/**
+ * Disable electron hardware acceleration if requested by environment.
+ * See https://stackoverflow.com/a/58351011/381166.
+ */
+if (process.env.ELECTRON_DISABLE_GPU) {
+  app.disableHardwareAcceleration();
+}
+
 /**
  * The step option
  * To reduce the number of rendered frames (step > 1)


### PR DESCRIPTION
Fix error "GL ERROR :GL_INVALID_OPERATION : glBufferData: <- error from previous GL command" on systems without hardware acceleration by disabling GPU usage by setting the environment variable ELECTRON_DISABLE_GPU.