### PR TITLE
Adds speed factor to render command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Options
 -o, --output   A name for the output file                                      [string]
 -q, --quality  The quality of the rendered image (1 - 100)                     [number]
 -s, --step     To reduce the number of rendered frames (step > 1) [number] [default: 1]
+-f, --speed-factor  Speed factor, multiply the frames delays by this factor    [number] [default: 1]
 ```
 
 ## Share

--- a/commands/render.js
+++ b/commands/render.js
@@ -292,7 +292,8 @@ function command(argv) {
   // For adjusting (calculating) the frames delays
   var adjustFramesDelaysOptions = {
     frameDelay: config.frameDelay,
-    maxIdleTime: config.maxIdleTime
+    maxIdleTime: config.maxIdleTime,
+    speedFactor: config.speedFactor
   };
 
   // For rendering the frames into PNG images
@@ -413,4 +414,11 @@ module.exports.builder = function(yargs) {
     default: 1
   });
 
+  // Define the speed-factor option
+  yargs.option('f', {
+    alias: 'speed-factor',
+    describe: 'Speed factor, multiply the frames delays by this factor',
+    type: 'number',
+    default: 1.0
+  });
 };

--- a/commands/render.js
+++ b/commands/render.js
@@ -293,7 +293,7 @@ function command(argv) {
   var adjustFramesDelaysOptions = {
     frameDelay: config.frameDelay,
     maxIdleTime: config.maxIdleTime,
-    speedFactor: config.speedFactor
+    speedFactor: argv.speedFactor
   };
 
   // For rendering the frames into PNG images


### PR DESCRIPTION
Seemed to me that the speed factor options is useful not only for `terminalizer play` but also for `terminalizer render`.

This PR adds this option to the latter command.