### PR TITLE
proof of concept: use upng-js to generate animated PNGs instead of GIFs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,22 @@
+# Rendering data
+render/frames/*
+render/data.json
+
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+
+# Dependency directories
+node_modules
+
+# Optional npm cache directory
+.npm
+
+# Build
+render/dist

--- a/app.js
+++ b/app.js
@@ -1,14 +1,14 @@
 /**
  * Terminalizer
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
-var yargs = require('yargs'),
-    requireDir = require('require-dir');
-var package = require('./package.json'),
-    commands = requireDir('./commands'),
-    DI = require('./di.js');
+var yargs = require("yargs"),
+  requireDir = require("require-dir");
+var package = require("./package.json"),
+  commands = requireDir("./commands"),
+  DI = require("./di.js");
 
 // Define the DI as a global object
 global.di = new DI();
@@ -17,88 +17,88 @@ global.di = new DI();
 global.ROOT_PATH = __dirname;
 
 // The base url of the Terminalizer website
-global.BASEURL = 'https://terminalizer.com';
+global.BASEURL = "https://terminalizer.com";
 
 // Dependency Injection
-di.require('chalk');
-di.require('async');
-di.require('request');
-di.require('death');
-di.require('path');
-di.require('os');
-di.require('electron');
-di.require('deepmerge');
-di.require('uuid');
-di.require('is_js', 'is');
-di.require('lodash', '_');
-di.require('fs-extra', 'fs');
-di.require('flowa', 'Flowa');
-di.require('js-yaml', 'yaml');
-di.require('performance-now', 'now');
-di.require('async-promises', 'asyncPromises');
-di.require('string-argv', 'stringArgv');
-di.require('progress', 'ProgressBar');
-di.require('gif-encoder', 'GIFEncoder');
-di.require('inquirer');
+di.require("chalk");
+di.require("async");
+di.require("request");
+di.require("death");
+di.require("path");
+di.require("os");
+di.require("electron");
+di.require("deepmerge");
+di.require("uuid");
+di.require("is_js", "is");
+di.require("lodash", "_");
+di.require("fs-extra", "fs");
+di.require("flowa", "Flowa");
+di.require("js-yaml", "yaml");
+di.require("performance-now", "now");
+di.require("async-promises", "asyncPromises");
+di.require("string-argv", "stringArgv");
+di.require("progress", "ProgressBar");
+di.require("gif-encoder", "GIFEncoder");
+di.require("inquirer");
 
-di.set('pty', require('@faressoft/node-pty-prebuilt'));
-di.set('PNG', require('pngjs').PNG);
-di.set('spawn', require('child_process').spawn);
-di.set('utility', require('./utility.js'));
-di.set('commands', commands);
-di.set('errorHandler', errorHandler);
+di.set("pty", require("@faressoft/node-pty-prebuilt"));
+di.set("PNG", require("pngjs").PNG);
+di.set("spawn", require("child_process").spawn);
+di.set("utility", require("./utility.js"));
+di.set("commands", commands);
+di.set("errorHandler", errorHandler);
 
 // Initialize yargs
-yargs.usage('Usage: $0 <command> [options]')
-     // Add link
-     .epilogue('For more information, check https://terminalizer.com')
-     // Set the version number
-     .version(package.version)
-     // Add aliases for version and help options
-     .alias({v: 'version', h: 'help'})
-     // Require to pass a command
-     .demandCommand(1, 'The command is missing')
-     // Strict mode
-     .strict()
-     // Set width to 90 cols
-     .wrap(100)
-     // Handle failures
-     .fail(errorHandler);
+yargs
+  .usage("Usage: $0 <command> [options]")
+  // Add link
+  .epilogue("For more information, check https://terminalizer.com")
+  // Set the version number
+  .version(package.version)
+  // Add aliases for version and help options
+  .alias({ v: "version", h: "help" })
+  // Require to pass a command
+  .demandCommand(1, "The command is missing")
+  // Strict mode
+  .strict()
+  // Set width to 90 cols
+  .wrap(100)
+  // Handle failures
+  .fail(errorHandler);
 
 // Load commands
-yargs.command(commands.init)
-     .command(commands.config)
-     .command(commands.record)
-     .command(commands.play)
-     .command(commands.render)
-     .command(commands.share)
-     .command(commands.generate)
+yargs
+  .command(commands.init)
+  .command(commands.config)
+  .command(commands.record)
+  .command(commands.play)
+  .command(commands.render)
+  .command(commands.share)
+  .command(commands.generate);
 
 debugger;
 
 try {
-
   // Parse the command line arguments
   yargs.parse();
-
 } catch (error) {
-
   // Print the error
   errorHandler(error);
-
 }
 
 /**
  * Print an error
- * 
+ *
  * @param {String|Error} error
  */
 function errorHandler(error) {
-
   error = error.toString();
 
-  console.error('Error: \n  ' + error + '\n');
-  console.error('Hint:\n  Use the ' + di.chalk.green('--help') + ' option to get help about the usage');
+  console.error("Error: \n  " + error + "\n");
+  console.error(
+    "Hint:\n  Use the " +
+      di.chalk.green("--help") +
+      " option to get help about the usage"
+  );
   process.exit(1);
-
 }

--- a/app.js
+++ b/app.js
@@ -42,7 +42,6 @@ di.require("gif-encoder", "GIFEncoder");
 di.require("inquirer");
 
 di.set("pty", require("@faressoft/node-pty-prebuilt"));
-di.set("PNG", require("pngjs").PNG);
 di.set("spawn", require("child_process").spawn);
 di.set("utility", require("./utility.js"));
 di.set("commands", commands);
@@ -92,9 +91,7 @@ try {
  * @param {String|Error} error
  */
 function errorHandler(error) {
-  error = error.toString();
-
-  console.error("Error: \n  " + error + "\n");
+  console.error("Error: " + (error.stack || error.toString()));
   console.error(
     "Hint:\n  Use the " +
       di.chalk.green("--help") +

--- a/bin/app.js
+++ b/bin/app.js
@@ -2,8 +2,8 @@
 
 /**
  * Terminalizer
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
-require('../app.js');
+require("../app.js");

--- a/commands/config.js
+++ b/commands/config.js
@@ -1,7 +1,7 @@
 /**
  * Config
  * Generate a config file in the current directory
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
@@ -9,25 +9,21 @@
  * Executed after the command completes its task
  */
 function done() {
-
-  console.log(di.chalk.green('Successfully Saved'));
-  console.log('The config file is saved into the file:');
-  console.log(di.chalk.magenta('config.yml'));
-
+  console.log(di.chalk.green("Successfully Saved"));
+  console.log("The config file is saved into the file:");
+  console.log(di.chalk.magenta("config.yml"));
 }
 
 /**
  * The command's main function
- * 
+ *
  * @param {Object} argv
  */
 function command(argv) {
-
   // Copy the default config file
-  di.fs.copySync(di.path.join(ROOT_PATH, 'config.yml'), 'config.yml');
+  di.fs.copySync(di.path.join(ROOT_PATH, "config.yml"), "config.yml");
 
   done();
-
 }
 
 ////////////////////////////////////////////////////
@@ -38,13 +34,13 @@ function command(argv) {
  * Command's usage
  * @type {String}
  */
-module.exports.command = 'config';
+module.exports.command = "config";
 
 /**
  * Command's description
  * @type {String}
  */
-module.exports.describe = 'Generate a config file in the current directory';
+module.exports.describe = "Generate a config file in the current directory";
 
 /**
  * Command's handler function

--- a/commands/generate.js
+++ b/commands/generate.js
@@ -1,7 +1,7 @@
 /**
  * Generate
  * Generate a web player for a recording file
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
@@ -9,21 +9,19 @@
  * Executed after the command completes its task
  */
 function done() {
-
   // Terminate the app
   process.exit();
-
 }
 
 /**
  * The command's main function
- * 
+ *
  * @param {Object} argv
  */
 function command(argv) {
-
-  console.log('This command is not implemented yet. It will be available in the next versions');
-
+  console.log(
+    "This command is not implemented yet. It will be available in the next versions"
+  );
 }
 
 ////////////////////////////////////////////////////
@@ -34,13 +32,13 @@ function command(argv) {
  * Command's usage
  * @type {String}
  */
-module.exports.command = 'generate <recordingFile>';
+module.exports.command = "generate <recordingFile>";
 
 /**
  * Command's description
  * @type {String}
  */
-module.exports.describe = 'Generate a web player for a recording file';
+module.exports.describe = "Generate a web player for a recording file";
 
 /**
  * Command's handler function
@@ -50,16 +48,14 @@ module.exports.handler = command;
 
 /**
  * Builder
- * 
+ *
  * @param {Object} yargs
  */
-module.exports.builder = function(yargs) {
-
+module.exports.builder = function (yargs) {
   // Define the recordingFile argument
-  yargs.positional('recordingFile', {
-    describe: 'the recording file',
-    type: 'string',
-    coerce: di.utility.loadYAML
+  yargs.positional("recordingFile", {
+    describe: "the recording file",
+    type: "string",
+    coerce: di.utility.loadYAML,
   });
-
 };

--- a/commands/init.js
+++ b/commands/init.js
@@ -4,9 +4,9 @@
  *
  * - Create a global config directory
  *   - For Windows, create it under `APPDATA`
- *   - For Linux and MacOS, create it under the home directory 
+ *   - For Linux and MacOS, create it under the home directory
  * - Copy the default config into it
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
@@ -14,42 +14,36 @@
  * Executed after the command completes its task
  */
 function done() {
-
-  console.log(di.chalk.green('The global config directory is created at'));
+  console.log(di.chalk.green("The global config directory is created at"));
   console.log(di.chalk.magenta(di.utility.getGlobalDirectory()));
-
 }
 
 /**
  * The command's main function
- * 
+ *
  * @param {Object} argv
  */
 function command(argv) {
-
   var globalPath = di.utility.getGlobalDirectory();
 
   // Create the global directory
   try {
-
     di.fs.mkdirSync(di.utility.getGlobalDirectory());
-
   } catch (error) {
-
     // Ignore `already exists` error
-    if (error.code != 'EEXIST') {
+    if (error.code != "EEXIST") {
       throw error;
     }
-
   }
 
   // Copy the default config file
-  di.fs.copySync(di.path.join(ROOT_PATH, 'config.yml'), 
-                 di.path.join(globalPath, 'config.yml'),
-                 {overwrite: true});
+  di.fs.copySync(
+    di.path.join(ROOT_PATH, "config.yml"),
+    di.path.join(globalPath, "config.yml"),
+    { overwrite: true }
+  );
 
   done();
-
 }
 
 ////////////////////////////////////////////////////
@@ -60,13 +54,13 @@ function command(argv) {
  * Command's usage
  * @type {String}
  */
-module.exports.command = 'init';
+module.exports.command = "init";
 
 /**
  * Command's description
  * @type {String}
  */
-module.exports.describe = 'Create a global config directory';
+module.exports.describe = "Create a global config directory";
 
 /**
  * Command's handler function

--- a/commands/play.js
+++ b/commands/play.js
@@ -1,57 +1,50 @@
 /**
  * Play
  * Play a recording file on your terminal
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
 /**
  * Print the passed content
- * 
+ *
  * @param {String}   content
  * @param {Function} callback
  */
 function playCallback(content, callback) {
-
   process.stdout.write(content);
   callback();
-
 }
 
 /**
  * Executed after the command completes its task
  */
 function done() {
-
   // Full reset for the terminal
-  process.stdout.write('\033c');
+  process.stdout.write("\033c");
   process.exit();
-
 }
 
 /**
  * The command's main function
- * 
+ *
  * @param {Object} argv
  */
 function command(argv) {
-
   process.stdin.pause();
 
   // Playing options
   var options = {
     frameDelay: argv.recordingFile.json.config.frameDelay,
-    maxIdleTime: argv.recordingFile.json.config.maxIdleTime
+    maxIdleTime: argv.recordingFile.json.config.maxIdleTime,
   };
 
   // Use the actual delays between frames as recorded
   if (argv.realTiming) {
-
     options = {
-      frameDelay: 'auto',
-      maxIdleTime: 'auto'
+      frameDelay: "auto",
+      maxIdleTime: "auto",
     };
-
   }
 
   // When app is closing
@@ -65,105 +58,95 @@ function command(argv) {
 
   // Play the recording records
   play(argv.recordingFile.json.records, playCallback, null, options);
-
 }
 
 /**
  * Adjust frames delays
- * 
+ *
  * Options:
- * 
+ *
  * - frameDelay (default: auto)
  *   - Delay between frames in ms
  *   - If the value is `auto` use the actual recording delays
- *   
+ *
  * - maxIdleTime (default: 2000)
  *   - Maximum delay between frames in ms
  *   - Ignored if the `frameDelay` isn't set to `auto`
  *   - Set to `auto` to prevent limiting the max idle time
- * 
+ *
  * - speedFactor (default: 1)
  *   - Multiply the frames delays by this factor
- * 
+ *
  * @param {Array}  records
  * @param {Object} options (optional)
  */
 function adjustFramesDelays(records, options) {
-
   // Default value for options
-  if (typeof options === 'undefined') {
+  if (typeof options === "undefined") {
     options = {};
   }
 
   // Default value for options.frameDelay
-  if (typeof options.frameDelay === 'undefined') {
-    options.frameDelay = 'auto';
+  if (typeof options.frameDelay === "undefined") {
+    options.frameDelay = "auto";
   }
 
   // Default value for options.maxIdleTime
-  if (typeof options.maxIdleTime === 'undefined') {
+  if (typeof options.maxIdleTime === "undefined") {
     options.maxIdleTime = 2000;
   }
 
   // Default value for options.speedFactor
-  if (typeof options.speedFactor === 'undefined') {
+  if (typeof options.speedFactor === "undefined") {
     options.speedFactor = 1;
   }
 
   // Foreach record
-  records.forEach(function(record) {
-
+  records.forEach(function (record) {
     // Adjust the delay according to the options
-    if (options.frameDelay != 'auto') {
+    if (options.frameDelay != "auto") {
       record.delay = options.frameDelay;
-    } else if (options.maxIdleTime != 'auto' && record.delay > options.maxIdleTime) {
+    } else if (
+      options.maxIdleTime != "auto" &&
+      record.delay > options.maxIdleTime
+    ) {
       record.delay = options.maxIdleTime;
     }
 
     // Apply speedFactor
     record.delay = record.delay * options.speedFactor;
-    
   });
-
 }
 
 /**
  * Play recording records
- * 
+ *
  * @param {Array}         records
  * @param {Function}      playCallback
  * @param {Function|Null} doneCallback
  */
 function play(records, playCallback, doneCallback) {
-
   var tasks = [];
 
   // Default value for doneCallback
-  if (typeof doneCallback === 'undefined') {
+  if (typeof doneCallback === "undefined") {
     doneCallback = null;
   }
 
   // Foreach record
-  records.forEach(function(record) {
-
-    tasks.push(function(callback) {
-
-      setTimeout(function() {
+  records.forEach(function (record) {
+    tasks.push(function (callback) {
+      setTimeout(function () {
         playCallback(record.content, callback);
       }, record.delay);
-      
     });
-    
   });
 
-  di.async.series(tasks, function(error, results) {
-
+  di.async.series(tasks, function (error, results) {
     if (doneCallback) {
       doneCallback();
     }
-
   });
-  
 }
 
 ////////////////////////////////////////////////////
@@ -174,13 +157,13 @@ function play(records, playCallback, doneCallback) {
  * Command's usage
  * @type {String}
  */
-module.exports.command = 'play <recordingFile>';
+module.exports.command = "play <recordingFile>";
 
 /**
  * Command's description
  * @type {String}
  */
-module.exports.describe = 'Play a recording file on your terminal';
+module.exports.describe = "Play a recording file on your terminal";
 
 /**
  * Command's handler function
@@ -190,34 +173,32 @@ module.exports.handler = command;
 
 /**
  * Builder
- * 
+ *
  * @param {Object} yargs
  */
-module.exports.builder = function(yargs) {
-
+module.exports.builder = function (yargs) {
   // Define the recordingFile argument
-  yargs.positional('recordingFile', {
-    describe: 'The recording file',
-    type: 'string',
-    coerce: di.utility.loadYAML
+  yargs.positional("recordingFile", {
+    describe: "The recording file",
+    type: "string",
+    coerce: di.utility.loadYAML,
   });
 
   // Define the real-timing option
-  yargs.option('r', {
-    alias: 'real-timing',
-    describe: 'Use the actual delays between frames as recorded',
-    type: 'boolean',
-    default: false
+  yargs.option("r", {
+    alias: "real-timing",
+    describe: "Use the actual delays between frames as recorded",
+    type: "boolean",
+    default: false,
   });
 
   // Define the speed-factor option
-  yargs.option('s', {
-    alias: 'speed-factor',
-    describe: 'Speed factor, multiply the frames delays by this factor',
-    type: 'number',
-    default: 1.0
+  yargs.option("s", {
+    alias: "speed-factor",
+    describe: "Speed factor, multiply the frames delays by this factor",
+    type: "number",
+    default: 1.0,
   });
-
 };
 
 ////////////////////////////////////////////////////

--- a/commands/record.js
+++ b/commands/record.js
@@ -1,7 +1,7 @@
 /**
  * Record
  * Record your terminal and create a recording file
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
@@ -32,56 +32,51 @@ var records = [];
 
 /**
  * Normalize the config file
- * 
+ *
  * - Set default values in the json and raw
  * - Change the formatting of the values in the json and raw
- * 
+ *
  * @param  {Object} config {json, raw}
  * @return {Object} {json, raw}
  */
 function normalizeConfig(config) {
-
   // Default value for command
   if (!config.json.command) {
-
     // Windows OS
-    if (di.os.platform() === 'win32') {
-      di.utility.changeYAMLValue(config, 'command', 'powershell.exe');
+    if (di.os.platform() === "win32") {
+      di.utility.changeYAMLValue(config, "command", "powershell.exe");
     } else {
-      di.utility.changeYAMLValue(config, 'command', 'bash -l');
+      di.utility.changeYAMLValue(config, "command", "bash -l");
     }
-
   }
 
   // Default value for cwd
   if (!config.json.cwd) {
-    di.utility.changeYAMLValue(config, 'cwd', process.cwd());
+    di.utility.changeYAMLValue(config, "cwd", process.cwd());
   } else {
-    di.utility.changeYAMLValue(config, 'cwd', di.path.resolve(config.json.cwd));
+    di.utility.changeYAMLValue(config, "cwd", di.path.resolve(config.json.cwd));
   }
 
   // Default value for cols
   if (di.is.not.number(config.json.cols)) {
-    di.utility.changeYAMLValue(config, 'cols', process.stdout.columns);
+    di.utility.changeYAMLValue(config, "cols", process.stdout.columns);
   }
 
   // Default value for rows
   if (di.is.not.number(config.json.rows)) {
-    di.utility.changeYAMLValue(config, 'rows', process.stdout.rows);
+    di.utility.changeYAMLValue(config, "rows", process.stdout.rows);
   }
 
   return config;
-
 }
 
 /**
  * Calculate the duration from the last inserted record in ms,
  * and update lastRecordTimestamp
- * 
+ *
  * @return {Number}
  */
 function getDuration() {
-
   // Calculate the duration from the last inserted record
   var duration = di.now().toFixed() - lastRecordTimestamp;
 
@@ -89,16 +84,14 @@ function getDuration() {
   lastRecordTimestamp = di.now().toFixed();
 
   return duration;
-
 }
 
 /**
  * When an input or output is received from the PTY instance
- * 
+ *
  * @param {Buffer} content
  */
 function onData(content) {
-
   process.stdout.write(content);
 
   var duration = getDuration();
@@ -111,47 +104,42 @@ function onData(content) {
 
   records.push({
     delay: duration,
-    content: content
+    content: content,
   });
-
 }
 
 /**
  * Executed after the command completes its task
  * Store the output file with reserving the comments
- * 
+ *
  * @param {Object} argv
  */
 function done(argv) {
-
-  var outputYAML = '';
+  var outputYAML = "";
 
   // Add config parent element
-  outputYAML += '# The configurations that used for the recording, feel free to edit them\n';
-  outputYAML += 'config:\n\n';
+  outputYAML +=
+    "# The configurations that used for the recording, feel free to edit them\n";
+  outputYAML += "config:\n\n";
 
   // Add the configurations with indentation
-  outputYAML += config.raw.replace(/^/gm, '  ');
+  outputYAML += config.raw.replace(/^/gm, "  ");
 
   // Add the records
-  outputYAML += '\n# Records, feel free to edit them\n';
-  outputYAML += di.yaml.dump({records: records});
+  outputYAML += "\n# Records, feel free to edit them\n";
+  outputYAML += di.yaml.dump({ records: records });
 
   // Store the data into the recording file
   try {
-
-    di.fs.writeFileSync(recordingFile, outputYAML, 'utf8');
-
+    di.fs.writeFileSync(recordingFile, outputYAML, "utf8");
   } catch (error) {
-
     return di.errorHandler(error);
-
   }
 
-  console.log(di.chalk.green('Successfully Recorded'));
-  console.log('The recording data is saved into the file:');
+  console.log(di.chalk.green("Successfully Recorded"));
+  console.log("The recording data is saved into the file:");
   console.log(di.chalk.magenta(recordingFile));
-  console.log('You can edit the file and even change the configurations.');
+  console.log("You can edit the file and even change the configurations.");
   console.log(
     "The command " +
       di.chalk.magenta("`terminalizer share`") +
@@ -163,42 +151,41 @@ function done(argv) {
   process.stdin.pause();
 
   if (argv.skipSharing) {
-    return
+    return;
   }
 
-  di.inquirer.prompt([
-    {
-      type: "confirm",
-      name: "share",
-      message: "Would you like to share your recording on terminalizer.com?",
-    },
-  ]).then(function(answers) {
+  di.inquirer
+    .prompt([
+      {
+        type: "confirm",
+        name: "share",
+        message: "Would you like to share your recording on terminalizer.com?",
+      },
+    ])
+    .then(function (answers) {
+      if (!answers.share) {
+        return;
+      }
 
-    if (!answers.share) {
-      return;
-    }
+      console.log(
+        di.chalk.green(
+          "Let's now share your recording on https://terminalizer.com"
+        )
+      );
 
-    console.log(
-      di.chalk.green(
-        "Let's now share your recording on https://terminalizer.com"
-      )
-    );
-
-    // Invoke the share command
-    di.commands.share.handler({
-      recordingFile: recordingFile,
+      // Invoke the share command
+      di.commands.share.handler({
+        recordingFile: recordingFile,
+      });
     });
-  });
-
 }
 
 /**
  * The command's main function
- * 
+ *
  * @param {Object} argv
  */
 function command(argv) {
-
   // Normalize the configurations
   config = normalizeConfig(argv.config);
 
@@ -207,7 +194,7 @@ function command(argv) {
 
   // Overwrite the command to be executed
   if (argv.command) {
-    di.utility.changeYAMLValue(config, 'command', argv.command);
+    di.utility.changeYAMLValue(config, "command", argv.command);
   }
 
   // Split the command and its arguments
@@ -220,28 +207,31 @@ function command(argv) {
     cols: config.json.cols,
     rows: config.json.rows,
     cwd: config.json.cwd,
-    env: di.deepmerge(process.env, config.json.env)
+    env: di.deepmerge(process.env, config.json.env),
   });
 
   var onInput = ptyProcess.write.bind(ptyProcess);
 
-  console.log('The recording session is started');
-  console.log('Press', di.chalk.green('CTRL+D'), 'to exit and save the recording');
+  console.log("The recording session is started");
+  console.log(
+    "Press",
+    di.chalk.green("CTRL+D"),
+    "to exit and save the recording"
+  );
 
   // Input and output capturing and redirection
-  process.stdin.on('data', onInput);
-  ptyProcess.on('data', onData);
-  ptyProcess.on('exit', function() {
-    process.stdin.removeListener('data', onInput);
+  process.stdin.on("data", onInput);
+  ptyProcess.on("data", onData);
+  ptyProcess.on("exit", function () {
+    process.stdin.removeListener("data", onInput);
     done(argv);
   });
 
   // Input and output normalization
-  process.stdout.setDefaultEncoding('utf8');
-  process.stdin.setEncoding('utf8');
+  process.stdout.setDefaultEncoding("utf8");
+  process.stdin.setEncoding("utf8");
   process.stdin.setRawMode(true);
   process.stdin.resume();
-
 }
 
 ////////////////////////////////////////////////////
@@ -252,74 +242,76 @@ function command(argv) {
  * Command's usage
  * @type {String}
  */
-module.exports.command = 'record <recordingFile>';
+module.exports.command = "record <recordingFile>";
 
 /**
  * Command's description
  * @type {String}
  */
-module.exports.describe = 'Record your terminal and create a recording file';
+module.exports.describe = "Record your terminal and create a recording file";
 
 /**
  * Handler
- * 
+ *
  * @param {Object} argv
  */
-module.exports.handler = function(argv) {
-
+module.exports.handler = function (argv) {
   // Default value for the config option
-  if (typeof argv.config == 'undefined') {
+  if (typeof argv.config == "undefined") {
     argv.config = di.utility.getDefaultConfig();
   }
 
   // Execute the command
   command(argv);
-  
 };
 
 /**
  * Builder
- * 
+ *
  * @param {Object} yargs
  */
-module.exports.builder = function(yargs) {
-
+module.exports.builder = function (yargs) {
   // Define the recordingFile argument
-  yargs.positional('recordingFile', {
-    describe: 'A name for the recording file',
-    type: 'string',
-    coerce: di._.partial(di.utility.resolveFilePath, di._, 'yml')
+  yargs.positional("recordingFile", {
+    describe: "A name for the recording file",
+    type: "string",
+    coerce: di._.partial(di.utility.resolveFilePath, di._, "yml"),
   });
 
   // Define the config option
-  yargs.option('c', {
-    alias: 'config',
-    type: 'string',
-    describe: 'Overwrite the default configurations',
+  yargs.option("c", {
+    alias: "config",
+    type: "string",
+    describe: "Overwrite the default configurations",
     requiresArg: true,
-    coerce: di.utility.loadYAML
+    coerce: di.utility.loadYAML,
   });
 
   // Define the config option
-  yargs.option('d', {
-    alias: 'command',
-    type: 'string',
-    describe: 'The command to be executed',
+  yargs.option("d", {
+    alias: "command",
+    type: "string",
+    describe: "The command to be executed",
     requiresArg: true,
-    default: null
+    default: null,
   });
 
   // Define the config option
-  yargs.option('k', {
-    alias: 'skip-sharing',
-    type: 'boolean',
-    describe: 'Skip sharing and showing the sharing prompt message',
+  yargs.option("k", {
+    alias: "skip-sharing",
+    type: "boolean",
+    describe: "Skip sharing and showing the sharing prompt message",
     requiresArg: false,
-    default: false
+    default: false,
   });
 
   // Add examples
-  yargs.example('$0 record foo', 'Start recording and create a recording file called foo.yml');
-  yargs.example('$0 record foo --config config.yml', 'Start recording with your own configurations');
-
+  yargs.example(
+    "$0 record foo",
+    "Start recording and create a recording file called foo.yml"
+  );
+  yargs.example(
+    "$0 record foo --config config.yml",
+    "Start recording with your own configurations"
+  );
 };

--- a/commands/render.js
+++ b/commands/render.js
@@ -1,7 +1,7 @@
 /**
  * Render
  * Render a recording file as an animated gif image
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
@@ -13,37 +13,40 @@
  * @return {ProgressBar}
  */
 function getProgressBar(operation, framesCount) {
-
-  return new di.ProgressBar(operation + ' ' + di.chalk.magenta('frame :current/:total') + ' :percent [:bar] :etas', {
-    width: 30,
-    total: framesCount
-  });
-
+  return new di.ProgressBar(
+    operation +
+      " " +
+      di.chalk.magenta("frame :current/:total") +
+      " :percent [:bar] :etas",
+    {
+      width: 30,
+      total: framesCount,
+    }
+  );
 }
 
 /**
  * Write the recording data into render/data.json
- * 
+ *
  * @param  {Object}  recordingFile
  * @return {Promise}
  */
 function writeRecordingData(recordingFile) {
-
-  return new Promise(function(resolve, reject) {
-
+  return new Promise(function (resolve, reject) {
     // Write the data into data.json file in the root path of the app
-    di.fs.writeFile(di.path.join(ROOT_PATH, 'render/data.json'), JSON.stringify(recordingFile.json), 'utf8', function(error) {
+    di.fs.writeFile(
+      di.path.join(ROOT_PATH, "render/data.json"),
+      JSON.stringify(recordingFile.json),
+      "utf8",
+      function (error) {
+        if (error) {
+          return reject(error);
+        }
 
-      if (error) {
-        return reject(error);
+        resolve();
       }
-
-      resolve();
-      
-    });
-    
+    );
   });
-
 }
 
 /**
@@ -53,80 +56,72 @@ function writeRecordingData(recordingFile) {
  * @return {Promise} resolve with the parsed PNG image
  */
 function loadPNG(path) {
-
-  return new Promise(function(resolve, reject) {
-
-    di.fs.readFile(path, function(error, imageData) {
-
+  return new Promise(function (resolve, reject) {
+    di.fs.readFile(path, function (error, imageData) {
       if (error) {
         return reject(error);
       }
 
-      new di.PNG().parse(imageData, function(error, data) {
-
+      new di.PNG().parse(imageData, function (error, data) {
         if (error) {
           return reject(error);
         }
 
         resolve(data);
-
       });
-      
     });
-    
   });
-
 }
 
 /**
  * Get the dimensions of the first rendered frame
- * 
+ *
  * @return {Promise}
  */
 function getFrameDimensions() {
-
   // The path of the first rendered frame
-  var framePath = di.path.join(ROOT_PATH, 'render/frames/0.png');
+  var framePath = di.path.join(ROOT_PATH, "render/frames/0.png");
 
   // Read and parse a PNG image file
-  return loadPNG(framePath).then(function(png) {
-
-    return({
+  return loadPNG(framePath).then(function (png) {
+    return {
       width: png.width,
-      height: png.height
-    });
-  
+      height: png.height,
+    };
   });
-
 }
 
 /**
  * Render the frames into PNG images
- * 
+ *
  * @param  {Array}   records [{delay, content}, ...]
  * @param  {Object}  options {step}
  * @return {Promise}
  */
 function renderFrames(records, options) {
-
-  return new Promise(function(resolve, reject) {
-
+  return new Promise(function (resolve, reject) {
     // The number of frames
     var framesCount = records.length;
 
     // Create a progress bar
-    var progressBar = getProgressBar('Rendering', Math.ceil(framesCount / options.step));
+    var progressBar = getProgressBar(
+      "Rendering",
+      Math.ceil(framesCount / options.step)
+    );
 
     // Execute the rendering process
-    var render = di.spawn(di.electron, [di.path.join(ROOT_PATH, 'render/index.js'), options.step], {detached: false});
+    var render = di.spawn(
+      di.electron,
+      [di.path.join(ROOT_PATH, "render/index.js"), options.step],
+      { detached: false }
+    );
 
-    render.stderr.on('data', function(error) {
+    render.stderr.on("data", function (error) {
       render.kill();
       reject(new Error(error));
     });
 
-    render.stdout.on('data', function(data) {
-
+    render.stdout.on("data", function (data) {
       // Is not a recordIndex (to skip Electron's logs or new lines)
       if (di.is.not.number(parseInt(data.toString()))) {
         return;
@@ -138,25 +133,20 @@ function renderFrames(records, options) {
       if (progressBar.complete) {
         resolve();
       }
-
     });
-
   });
-
 }
 
 /**
  * Merge the rendered frames into an animated GIF image
- * 
+ *
  * @param  {Array}   records         [{delay, content}, ...]
  * @param  {Object}  options         {quality, repeat, step, outputFile}
  * @param  {Object}  frameDimensions {width, height}
  * @return {Promise}
  */
 function mergeFrames(records, options, frameDimensions) {
-
-  return new Promise(function(resolve, reject) {
-
+  return new Promise(function (resolve, reject) {
     // The number of frames
     var framesCount = records.length;
 
@@ -164,11 +154,14 @@ function mergeFrames(records, options, frameDimensions) {
     var stepsCounter = 0;
 
     // Create a progress bar
-    var progressBar = getProgressBar('Merging', Math.ceil(framesCount / options.step));
+    var progressBar = getProgressBar(
+      "Merging",
+      Math.ceil(framesCount / options.step)
+    );
 
     // The gif image
     var gif = new di.GIFEncoder(frameDimensions.width, frameDimensions.height, {
-      highWaterMark: 5 * 1024 * 1024
+      highWaterMark: 5 * 1024 * 1024,
     });
 
     // Pipe
@@ -184,101 +177,91 @@ function mergeFrames(records, options, frameDimensions) {
     gif.writeHeader();
 
     // Foreach frame
-    di.async.eachOfSeries(records, function(frame, index, callback) {
+    di.async.eachOfSeries(
+      records,
+      function (frame, index, callback) {
+        if (stepsCounter != 0) {
+          stepsCounter = (stepsCounter + 1) % options.step;
+          return callback();
+        }
 
-      if (stepsCounter != 0) {
         stepsCounter = (stepsCounter + 1) % options.step;
-        return callback();
+
+        // The path of the rendered frame
+        var framePath = di.path.join(
+          ROOT_PATH,
+          "render/frames",
+          index + ".png"
+        );
+
+        // Read and parse the rendered frame
+        loadPNG(framePath)
+          .then(function (png) {
+            progressBar.tick();
+
+            // Set the duration (the delay of the next frame)
+            // The % is used to take the delay of the first frame
+            // as the duration of the last frame
+            gif.setDelay(records[(index + 1) % framesCount].delay);
+
+            // Add frames
+            gif.addFrame(png.data);
+
+            // Next
+            callback();
+          })
+          .catch(function (error) {
+            callback(error);
+          });
+      },
+      function (error) {
+        if (error) {
+          return reject(error);
+        }
+
+        // Write the footer
+        gif.finish();
+        resolve();
       }
-
-      stepsCounter = (stepsCounter + 1) % options.step;
-
-      // The path of the rendered frame
-      var framePath = di.path.join(ROOT_PATH, 'render/frames', index + '.png');
-
-      // Read and parse the rendered frame
-      loadPNG(framePath).then(function(png) {
-
-        progressBar.tick();
-
-        // Set the duration (the delay of the next frame)
-        // The % is used to take the delay of the first frame
-        // as the duration of the last frame
-        gif.setDelay(records[(index + 1) % framesCount].delay);
-
-        // Add frames
-        gif.addFrame(png.data);
-
-        // Next
-        callback();
-
-      }).catch(function(error) {
-
-        callback(error);
-        
-      });
-
-    }, function(error) {
-
-      if (error) {
-        return reject(error);
-      }
-
-      // Write the footer
-      gif.finish();
-      resolve();
-
-    });
-
-
+    );
   });
-
 }
 
 /**
- * Delete the temporary rendered PNG images 
- * 
+ * Delete the temporary rendered PNG images
+ *
  * @return {Promise}
  */
 function cleanup() {
-
-  return new Promise(function(resolve, reject) {
-
-    di.fs.emptyDir(di.path.join(ROOT_PATH, 'render/frames'), function(error) {
-      
+  return new Promise(function (resolve, reject) {
+    di.fs.emptyDir(di.path.join(ROOT_PATH, "render/frames"), function (error) {
       if (error) {
         return reject(error);
       }
 
       resolve();
-
     });
-
   });
-
 }
 
 /**
  * Executed after the command completes its task
- * 
+ *
  * @param {String} outputFile the path of the rendered image
  */
 function done(outputFile) {
-
-  console.log('\n' + di.chalk.green('Successfully Rendered'));
-  console.log('The animated GIF image is saved into the file:');
+  console.log("\n" + di.chalk.green("Successfully Rendered"));
+  console.log("The animated GIF image is saved into the file:");
   console.log(di.chalk.magenta(outputFile));
   process.exit();
-
 }
 
 /**
  * The command's main function
- * 
+ *
  * @param {Object} argv
  */
 function command(argv) {
-
   // Frames
   var records = argv.recordingFile.json.records;
   var config = argv.recordingFile.json.config;
@@ -287,17 +270,20 @@ function command(argv) {
   var framesCount = records.length;
 
   // The path of the output file
-  var outputFile = di.utility.resolveFilePath('render' + (new Date()).getTime(), 'gif');
+  var outputFile = di.utility.resolveFilePath(
+    "render" + new Date().getTime(),
+    "gif"
+  );
 
   // For adjusting (calculating) the frames delays
   var adjustFramesDelaysOptions = {
     frameDelay: config.frameDelay,
-    maxIdleTime: config.maxIdleTime
+    maxIdleTime: config.maxIdleTime,
   };
 
   // For rendering the frames into PNG images
   var renderingOptions = {
-    step: argv.step
+    step: argv.step,
   };
 
   // For merging the rendered frames into an animated GIF image
@@ -305,7 +291,7 @@ function command(argv) {
     quality: config.quality,
     repeat: config.repeat,
     step: argv.step,
-    outputFile: outputFile
+    outputFile: outputFile,
   };
 
   // Overwrite the quality of the rendered image
@@ -320,35 +306,37 @@ function command(argv) {
   }
 
   // Tasks
-  di.asyncPromises.waterfall([
+  di.asyncPromises
+    .waterfall([
+      // Remove all previously rendered frames
+      cleanup,
 
-    // Remove all previously rendered frames
-    cleanup,
+      // Write the recording data into render/data.json
+      di._.partial(writeRecordingData, argv.recordingFile),
 
-    // Write the recording data into render/data.json
-    di._.partial(writeRecordingData, argv.recordingFile),
+      // Render the frames into PNG images
+      di._.partial(renderFrames, records, renderingOptions),
 
-    // Render the frames into PNG images
-    di._.partial(renderFrames, records, renderingOptions),
+      // Adjust frames delays
+      di._.partial(
+        di.commands.play.adjustFramesDelays,
+        records,
+        adjustFramesDelaysOptions
+      ),
 
-    // Adjust frames delays
-    di._.partial(di.commands.play.adjustFramesDelays, records, adjustFramesDelaysOptions),
+      // Get the dimensions of the first rendered frame
+      di._.partial(getFrameDimensions),
 
-    // Get the dimensions of the first rendered frame
-    di._.partial(getFrameDimensions),
+      // Merge the rendered frames into an animated GIF image
+      di._.partial(mergeFrames, records, mergingOptions),
 
-    // Merge the rendered frames into an animated GIF image
-    di._.partial(mergeFrames, records, mergingOptions),
-
-    // Delete the temporary rendered PNG images 
-    cleanup
-
-  ]).then(function() {
-
-    done(outputFile);
-    
-  }).catch(di.errorHandler);
-
+      // Delete the temporary rendered PNG images
+      cleanup,
+    ])
+    .then(function () {
+      done(outputFile);
+    })
+    .catch(di.errorHandler);
 }
 
 ////////////////////////////////////////////////////
@@ -359,13 +347,13 @@ function command(argv) {
  * Command's usage
  * @type {String}
  */
-module.exports.command = 'render <recordingFile>';
+module.exports.command = "render <recordingFile>";
 
 /**
  * Command's description
  * @type {String}
  */
-module.exports.describe = 'Render a recording file as an animated gif image';
+module.exports.describe = "Render a recording file as an animated gif image";
 
 /**
  * Command's handler function
@@ -375,42 +363,40 @@ module.exports.handler = command;
 
 /**
  * Builder
- * 
+ *
  * @param {Object} yargs
  */
-module.exports.builder = function(yargs) {
-
+module.exports.builder = function (yargs) {
   // Define the recordingFile argument
-  yargs.positional('recordingFile', {
-    describe: 'The recording file',
-    type: 'string',
-    coerce: di.utility.loadYAML
+  yargs.positional("recordingFile", {
+    describe: "The recording file",
+    type: "string",
+    coerce: di.utility.loadYAML,
   });
 
   // Define the output option
-  yargs.option('o', {
-    alias: 'output',
-    type: 'string',
-    describe: 'A name for the output file',
+  yargs.option("o", {
+    alias: "output",
+    type: "string",
+    describe: "A name for the output file",
     requiresArg: true,
-    coerce: di._.partial(di.utility.resolveFilePath, di._, 'gif')
+    coerce: di._.partial(di.utility.resolveFilePath, di._, "gif"),
   });
 
   // Define the quality option
-  yargs.option('q', {
-    alias: 'quality',
-    type: 'number',
-    describe: 'The quality of the rendered image (1 - 100)',
-    requiresArg: true
+  yargs.option("q", {
+    alias: "quality",
+    type: "number",
+    describe: "The quality of the rendered image (1 - 100)",
+    requiresArg: true,
   });
 
   // Define the quality option
-  yargs.option('s', {
-    alias: 'step',
-    type: 'number',
-    describe: 'To reduce the number of rendered frames (step > 1)',
+  yargs.option("s", {
+    alias: "step",
+    type: "number",
+    describe: "To reduce the number of rendered frames (step > 1)",
     requiresArg: true,
-    default: 1
+    default: 1,
   });
-
 };

--- a/commands/share.js
+++ b/commands/share.js
@@ -1,7 +1,7 @@
 /**
  * Share
  * Upload a recording file and get a link for an online player
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
@@ -11,30 +11,26 @@
  * @param {String} url the url of the uploaded recording
  */
 function done(url) {
-
-  console.log(di.chalk.green('Successfully Uploaded'));
-  console.log('The recording is available on the link:');
+  console.log(di.chalk.green("Successfully Uploaded"));
+  console.log("The recording is available on the link:");
   console.log(di.chalk.magenta(url));
   process.exit();
-
 }
 
 /**
  * Check if the value is not an empty value
  *
  * - Throw `Required field` if empty
- * 
+ *
  * @param  {String} input
  * @return {Boolean}
  */
 function isSet(input) {
-
   if (!input) {
-    return new Error('Required field');
+    return new Error("Required field");
   }
 
   return true;
-
 }
 
 /**
@@ -48,7 +44,6 @@ function isSet(input) {
  * @return {Promise}
  */
 function getToken(context) {
-
   var token = di.utility.getToken();
 
   // Already registered
@@ -58,33 +53,30 @@ function getToken(context) {
 
   token = di.utility.generateToken();
 
-  console.log('Open the following link in your browser and login into your account');
-  console.log(di.chalk.dim(BASEURL + '/token?token=' + token) + '\n');
+  console.log(
+    "Open the following link in your browser and login into your account"
+  );
+  console.log(di.chalk.dim(BASEURL + "/token?token=" + token) + "\n");
 
   // Continue action
-  return new Promise(function(resolve, reject) {
-
-    console.log('When you do it, press any key to continue');
+  return new Promise(function (resolve, reject) {
+    console.log("When you do it, press any key to continue");
     process.stdin.setRawMode(true);
     process.stdin.resume();
 
-    process.stdin.once('data', function handler(data) {
-
+    process.stdin.once("data", function handler(data) {
       // Check if CTRL+C is pressed to exit
-      if (data == '\u0003' || data == '\u0003') {
+      if (data == "\u0003" || data == "\u0003") {
         process.exit();
       }
 
-      console.log(di.chalk.dim('Enjoy !') + '\n');
+      console.log(di.chalk.dim("Enjoy !") + "\n");
       process.stdin.pause();
       process.stdin.setRawMode(false);
 
       resolve(token);
-
     });
-    
   });
-
 }
 
 /**
@@ -97,50 +89,48 @@ function getToken(context) {
  * @return {Promise}
  */
 function getMeta(context) {
-
   var platform = di.utility.getOS();
 
   // Already executed
-  if (typeof context.getMeta != 'undefined') {
+  if (typeof context.getMeta != "undefined") {
     return Promise.resolve(context.getMeta);
   }
 
-  console.log('Please enter some details about your recording');
+  console.log("Please enter some details about your recording");
 
-  return di.inquirer.prompt([
-    {
-      type: 'input',
-      name: 'title',
-      message: 'Title',
-      validate: isSet
-    },
-    {
-      type: 'input',
-      name: 'description',
-      message: 'Description',
-      validate: isSet
-    },
-    {
-      type: 'input',
-      name: 'tags',
-      message: 'Tags ' + di.chalk.dim('such as git,bash,game'),
-      validate: isSet,
-      default: platform
-    }
-  ]).then(function(answers) {
+  return di.inquirer
+    .prompt([
+      {
+        type: "input",
+        name: "title",
+        message: "Title",
+        validate: isSet,
+      },
+      {
+        type: "input",
+        name: "description",
+        message: "Description",
+        validate: isSet,
+      },
+      {
+        type: "input",
+        name: "tags",
+        message: "Tags " + di.chalk.dim("such as git,bash,game"),
+        validate: isSet,
+        default: platform,
+      },
+    ])
+    .then(function (answers) {
+      var params = Object.assign({}, answers);
 
-    var params = Object.assign({}, answers);
+      // Add the platform
+      params.platform = platform;
 
-    // Add the platform
-    params.platform = platform;
+      // Print a new line
+      console.log();
 
-    // Print a new line
-    console.log();
-
-    return params;
-
-  });
-
+      return params;
+    });
 }
 
 /**
@@ -151,20 +141,19 @@ function getMeta(context) {
  *   - Jump into the getToken task
  *
  * - Resolve with the url of the uploaded recording
- * 
+ *
  * @param  {Object}  context
  * @return {Promise}
  */
 function shareRecording(context) {
-
   var self = this;
   var token = context.getToken;
   var meta = context.getMeta;
   var recordingFile = context.recordingFile;
-  
+
   var options = {
-    method: 'POST',
-    url: BASEURL + '/v1/recording',
+    method: "POST",
+    url: BASEURL + "/v1/recording",
     formData: {
       title: meta.title,
       description: meta.description,
@@ -174,83 +163,77 @@ function shareRecording(context) {
       file: {
         value: di.fs.createReadStream(recordingFile),
         options: {
-          filename: 'recording.yml',
-          contentType: 'application/x-yaml'
-        }
-      } 
-    }
+          filename: "recording.yml",
+          contentType: "application/x-yaml",
+        },
+      },
+    },
   };
 
-  return new Promise(function(resolve, reject) {
-
-    di.request(options, function(error, response, body) {
-
+  return new Promise(function (resolve, reject) {
+    di.request(options, function (error, response, body) {
       if (error) {
         return reject(error);
       }
 
       // Internal server error
       if (response.statusCode == 500) {
-        return reject(body.errors.join('\n'));
+        return reject(body.errors.join("\n"));
       }
 
       // Invalid input
       if (response.statusCode == 400) {
-        return reject(body.errors.join('\n'));
+        return reject(body.errors.join("\n"));
       }
 
       // Invalid token
       if (response.statusCode == 401) {
         di.utility.removeToken();
-        self.jump('getToken');
+        self.jump("getToken");
         return resolve();
       }
 
       // Unexpected error
       if (response.statusCode != 200) {
-        return reject(new Error('Something went wrong, try again later'));
+        return reject(new Error("Something went wrong, try again later"));
       }
 
       // Parse the response body
       body = JSON.parse(body);
 
       resolve(body.url);
-
     });
-
   });
-
 }
 
 /**
  * The command's main function
- * 
+ *
  * @param {Object} argv
  */
 function command(argv) {
-
   // No global config
   if (!di.utility.isGlobalDirectoryCreated()) {
-    require('./init.js').handler();
+    require("./init.js").handler();
   }
 
-  di.Flowa.run({
+  di.Flowa.run(
+    {
+      // Get a token for uploading recordings
+      getToken: getToken,
 
-    // Get a token for uploading recordings
-    getToken: getToken,
+      // Ask the user to enter meta data about the recording
+      getMeta: getMeta,
 
-    // Ask the user to enter meta data about the recording
-    getMeta: getMeta,
-
-    // Upload the recording
-    shareRecording: shareRecording
-
-  }, argv).then(function(context) {
-  
-    done(context.shareRecording);
-  
-  }).catch(di.errorHandler);
-
+      // Upload the recording
+      shareRecording: shareRecording,
+    },
+    argv
+  )
+    .then(function (context) {
+      done(context.shareRecording);
+    })
+    .catch(di.errorHandler);
 }
 
 ////////////////////////////////////////////////////
@@ -261,13 +244,14 @@ function command(argv) {
  * Command's usage
  * @type {String}
  */
-module.exports.command = 'share <recordingFile>';
+module.exports.command = "share <recordingFile>";
 
 /**
  * Command's description
  * @type {String}
  */
-module.exports.describe = 'Upload a recording file and get a link for an online player';
+module.exports.describe =
+  "Upload a recording file and get a link for an online player";
 
 /**
  * Command's handler function
@@ -277,16 +261,14 @@ module.exports.handler = command;
 
 /**
  * Builder
- * 
+ *
  * @param {Object} yargs
  */
-module.exports.builder = function(yargs) {
-
+module.exports.builder = function (yargs) {
   // Define the recordingFile argument
-  yargs.positional('recordingFile', {
-    describe: 'the recording file',
-    type: 'string',
-    coerce: di._.partial(di.utility.resolveFilePath, di._, 'yml')
+  yargs.positional("recordingFile", {
+    describe: "the recording file",
+    type: "string",
+    coerce: di._.partial(di.utility.resolveFilePath, di._, "yml"),
   });
-
 };

--- a/di.js
+++ b/di.js
@@ -1,17 +1,16 @@
 /**
  * Dependency injection
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
-var path = require('path'),
-    _ = require('lodash');
+var path = require("path"),
+  _ = require("lodash");
 
 /**
  * Dependency injection
  */
 function DI() {
-
   /**
    * Injected dependecies
    * @type {Object}
@@ -24,22 +23,20 @@ function DI() {
    */
   this._proxy = new Proxy(this, {
     get: this.getHandler,
-    set: this.setHandler
+    set: this.setHandler,
   });
 
   return this._proxy;
-
 }
 
 /**
  * Trap for getting a property value
- * 
+ *
  * @param  {Object} target
  * @param  {String} key
  * @return {*}
  */
-DI.prototype.getHandler = function(target, key) {
-
+DI.prototype.getHandler = function (target, key) {
   if (key in target) {
     return target[key];
   }
@@ -47,19 +44,17 @@ DI.prototype.getHandler = function(target, key) {
   if (key in target._dependencies) {
     return target._dependencies[key];
   }
-
 };
 
 /**
  * Trap for setting a property value
- * 
+ *
  * @param  {Object} target
  * @param  {String} key
  * @param  {*}      value
  * @return {*}
  */
-DI.prototype.setHandler = function(target, key, value) {
-
+DI.prototype.setHandler = function (target, key, value) {
   if (key in target) {
     throw new Error(`It is not allowed to set '${key}'`);
   }
@@ -67,7 +62,6 @@ DI.prototype.setHandler = function(target, key, value) {
   target._dependencies[key] = value;
 
   return true;
-
 };
 
 /**
@@ -81,74 +75,62 @@ DI.prototype.setHandler = function(target, key, value) {
  * - Resolve third party packages as the native `require`.
  * - Resolve our own scripts with paths relative to
  *   the app's root path `require`.
- * 
+ *
  * @param {String} moduleName
  * @param {String} key        (Optional) (Default: the moduleName camel cased)
  */
-DI.prototype.require = function(moduleName, key) {
-
+DI.prototype.require = function (moduleName, key) {
   var parsedModuleName = path.parse(moduleName);
 
   // Default value for key
-  if (typeof key == 'undefined') {
+  if (typeof key == "undefined") {
     key = _.camelCase(parsedModuleName.name);
   }
 
   // Is not a third party package
-  if (parsedModuleName.dir != '') {
-
+  if (parsedModuleName.dir != "") {
     // Resolve the path to an absolute path
     moduleName = path.resolve(this._getAppRootPath(), moduleName);
-
   }
 
   this._dependencies[key] = require(moduleName);
-
 };
 
 /**
  * Inject a dependency
- * 
+ *
  * @param {String} key
  * @param {*}      value
  */
-DI.prototype.set = function(key, value) {
-
+DI.prototype.set = function (key, value) {
   this[key] = value;
-  
 };
 
 /**
  * Get an injected dependency
- * 
+ *
  * @param  {String} key
  * @return {*}
  */
-DI.prototype.get = function(key) {
-
+DI.prototype.get = function (key) {
   return this[key];
-  
 };
 
 /**
  * Get the root path of the app
  *
  * - Follow the module.parent.parent... etc until null
- * 
+ *
  * @return {String}
  */
-DI.prototype._getAppRootPath = function() {
-
+DI.prototype._getAppRootPath = function () {
   var parent = module.parent;
 
   while (parent.parent) {
-
     parent = parent.parent;
-    
   }
 
   return path.dirname(parent.filename);
-
 };
 
 module.exports = DI;

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,14 @@
         }
       }
     },
+    "@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "requires": {
+        "pako": "^1.0.10"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -4361,8 +4369,7 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -4498,11 +4505,6 @@
       "requires": {
         "find-up": "^3.0.0"
       }
-    },
-    "pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,84 +54,10 @@
             "mimic-response": "^2.0.0"
           }
         },
-        "expand-template": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-          "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-        },
         "mimic-response": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
           "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
-        },
-        "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-        },
-        "node-abi": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.12.0.tgz",
-          "integrity": "sha512-VhPBXCIcvmo/5K8HPmnWJyyhvgKxnHTUMXR/XwGHV68+wrgkzST4UmQrY/XszSWA5dtnXpNp528zkcyJ/pzVcw==",
-          "requires": {
-            "semver": "^5.4.1"
-          }
-        },
-        "prebuild-install": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
-          "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^2.0.3",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "napi-build-utils": "^1.0.1",
-            "node-abi": "^2.7.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "pump": "^3.0.0",
-            "rc": "^1.2.7",
-            "simple-get": "^3.0.3",
-            "tar-fs": "^2.0.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-            },
-            "mkdirp": {
-              "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-              "requires": {
-                "minimist": "^1.2.5"
-              }
-            }
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "simple-get": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-          "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-          "requires": {
-            "decompress-response": "^4.2.0",
-            "once": "^1.3.1",
-            "simple-concat": "^1.0.0"
-          }
         }
       }
     },
@@ -1457,14 +1383,6 @@
         "postcss-modules-values": "^1.3.0",
         "postcss-value-parser": "^3.3.0",
         "source-list-map": "^2.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        }
       }
     },
     "css-selector-tokenizer": {
@@ -1952,6 +1870,11 @@
         }
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -2329,16 +2252,6 @@
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
-      },
-      "dependencies": {
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        }
       }
     },
     "fs-write-stream-atomic": {
@@ -2373,25 +2286,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2401,13 +2318,15 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2417,37 +2336,43 @@
         },
         "chownr": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "3.2.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2456,25 +2381,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2483,13 +2412,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2505,7 +2436,8 @@
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2519,13 +2451,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2534,7 +2468,8 @@
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2543,7 +2478,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2553,19 +2489,22 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2574,13 +2513,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2589,13 +2530,15 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.9.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2605,7 +2548,8 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2614,7 +2558,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2623,13 +2568,15 @@
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2640,7 +2587,8 @@
         },
         "node-pre-gyp": {
           "version": "0.14.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2658,7 +2606,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2668,7 +2617,8 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2677,13 +2627,15 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2693,7 +2645,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2705,19 +2658,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2726,19 +2682,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2748,19 +2707,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2772,7 +2734,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -2780,7 +2743,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2795,7 +2759,8 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2804,43 +2769,50 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2851,7 +2823,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2860,7 +2833,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2869,13 +2843,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2890,13 +2866,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2905,13 +2883,15 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true,
           "optional": true
         }
@@ -4052,9 +4032,7 @@
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4090,6 +4068,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-abi": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.12.0.tgz",
+      "integrity": "sha512-VhPBXCIcvmo/5K8HPmnWJyyhvgKxnHTUMXR/XwGHV68+wrgkzST4UmQrY/XszSWA5dtnXpNp528zkcyJ/pzVcw==",
+      "requires": {
+        "semver": "^5.4.1"
+      }
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -4580,10 +4566,38 @@
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
     },
+    "prebuild-install": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+      "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      }
+    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+    },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
     },
     "process": {
       "version": "0.11.10",
@@ -5134,6 +5148,31 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+        }
+      }
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@electron/get": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.9.0.tgz",
-      "integrity": "sha512-OBIKtF6ttIJotDXe4KJMUyTBO4xMii+mFjlA8R4CORuD4HvCUaCK3lPjhdTRCvuEv6gzWNbAvd9DNBv0v780lw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.2.tgz",
+      "integrity": "sha512-vAuHUbfvBQpYTJ5wB7uVIDq5c/Ry0fiTBMs7lnEYAo/qXXppIVcWdfBr57u6eRnKdVso7KSiH6p/LbQAG6Izrg==",
       "requires": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -31,9 +31,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         }
       }
     },
@@ -149,9 +149,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.29.tgz",
-      "integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ=="
+      "version": "12.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
+      "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -784,9 +784,9 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
-      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
+      "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==",
       "optional": true
     },
     "brace-expansion": {
@@ -1032,9 +1032,9 @@
       },
       "dependencies": {
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -1361,9 +1361,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
+      "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==",
       "optional": true
     },
     "core-util-is": {
@@ -1504,11 +1504,11 @@
       "integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg="
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -1708,9 +1708,9 @@
       }
     },
     "electron": {
-      "version": "7.1.14",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.14.tgz",
-      "integrity": "sha512-y9Nbja4rl+5fPVw9e/lFudwRax3a+jenzS7WXzUkjF7GI8YFxNH2eH9K9PZFNuSwc/OOCja2ul70+D44tKTQEw==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-11.0.3.tgz",
+      "integrity": "sha512-nNfbLi7Q1xfJXOEO2adck5TS6asY4Jxc332E4Te8XfQ9hcaC3GiCdeEqk9FndNCwxhJA5Lr9jfSGRTwWebFa/w==",
       "requires": {
         "@electron/get": "^1.0.1",
         "@types/node": "^12.0.12",
@@ -3009,24 +3009,42 @@
       }
     },
     "global-agent": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.8.tgz",
-      "integrity": "sha512-VpBe/rhY6Rw2VDOTszAMNambg+4Qv8j0yiTNDYEXXXxkUNGWLHp8A3ztK4YDBbFNcWF4rgsec6/5gPyryya/+A==",
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.12.tgz",
+      "integrity": "sha512-caAljRMS/qcDo69X9BfkgrihGUgGx44Fb4QQToNQjsiWh+YlQ66uqYVAdA8Olqit+5Ng0nkz09je3ZzANMZcjg==",
       "optional": true,
       "requires": {
-        "boolean": "^3.0.0",
-        "core-js": "^3.6.4",
+        "boolean": "^3.0.1",
+        "core-js": "^3.6.5",
         "es6-error": "^4.1.1",
-        "matcher": "^2.1.0",
-        "roarr": "^2.15.2",
-        "semver": "^7.1.2",
-        "serialize-error": "^5.0.0"
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "optional": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "semver": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "optional": true
         }
       }
@@ -3778,18 +3796,18 @@
       }
     },
     "matcher": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.1.0.tgz",
-      "integrity": "sha512-o+nZr+vtJtgPNklyeUKkkH42OsK8WAfdgaJE2FNxcjLPg+5QbeEoT6vRj8Xq/iv18JlQ9cmKsEu0b94ixWf1YQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "optional": true,
       "requires": {
-        "escape-string-regexp": "^2.0.0"
+        "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "optional": true
         }
       }
@@ -4948,12 +4966,12 @@
       }
     },
     "roarr": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
-      "integrity": "sha512-jmaDhK9CO4YbQAV8zzCnq9vjAqeO489MS5ehZ+rXmFiPFFE6B+S9KYO6prjmLJ5A0zY3QxVlQdrIya7E/azz/Q==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "optional": true,
       "requires": {
-        "boolean": "^3.0.0",
+        "boolean": "^3.0.1",
         "detect-node": "^2.0.4",
         "globalthis": "^1.0.1",
         "json-stringify-safe": "^5.0.1",
@@ -5036,12 +5054,12 @@
       "optional": true
     },
     "serialize-error": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
-      "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "optional": true,
       "requires": {
-        "type-fest": "^0.8.0"
+        "type-fest": "^0.13.1"
       }
     },
     "serialize-javascript": {
@@ -5757,9 +5775,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "optional": true
     },
     "typedarray": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chalk": "^2.4.2",
     "death": "^1.1.0",
     "deepmerge": "^2.2.1",
-    "electron": "^7.1.14",
+    "electron": "^11.0.3",
     "flowa": "^4.0.2",
     "fs-extra": "^5.0.0",
     "gif-encoder": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   ],
   "dependencies": {
     "@faressoft/node-pty-prebuilt": "^0.9.0",
+    "@pdf-lib/upng": "^1.0.1",
     "async": "^2.6.3",
     "async-promises": "^0.2.2",
     "chalk": "^2.4.2",
@@ -58,7 +59,6 @@
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "performance-now": "^2.1.0",
-    "pngjs": "^3.4.0",
     "progress": "^2.0.3",
     "request": "^2.88.2",
     "require-dir": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "scripts": {
     "dev": "NODE_ENV=development webpack --colors --watch",
     "build": "NODE_ENV=production webpack --optimize-minimize --progress --colors",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "prettier-check": "prettier --check '**/*.js'",
+    "prettier-write": "prettier --write '**/*.js'"
   },
   "keywords": [
     "terminal",
@@ -70,6 +72,7 @@
     "css-loader": "^1.0.0",
     "jquery": "^3.4.1",
     "mini-css-extract-plugin": "^0.4.5",
+    "prettier": "^2.2.1",
     "terminalizer-player": "^0.4.1",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",

--- a/render/index.js
+++ b/render/index.js
@@ -1,15 +1,15 @@
 /**
  * Render the frames into PNG images
  * An electron app, takes one command line argument `step`
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
-var path          = require('path'),
-    app           = require('electron').app,
-    BrowserWindow = require('electron').BrowserWindow,
-    ipcMain       = require('electron').ipcMain,
-    os            = require('os');
+var path = require("path"),
+  app = require("electron").app,
+  BrowserWindow = require("electron").BrowserWindow,
+  ipcMain = require("electron").ipcMain,
+  os = require("os");
 
 /**
  * The step option
@@ -22,47 +22,45 @@ global.step = process.argv[2] || 1;
  * The temporary rendering directory's path
  * @type {String}
  */
-global.renderDir = path.join(__dirname, 'frames');
+global.renderDir = path.join(__dirname, "frames");
 
 // Hide the Dock for macOS
-if (os.platform() == 'darwin') {
+if (os.platform() == "darwin") {
   app.dock.hide();
 }
 
 // When the app is ready
-app.on('ready', createWindow);
+app.on("ready", createWindow);
 
 /**
  * Create a hidden browser window and load the rendering page
  */
 function createWindow() {
-
   // Create a browser window
   var win = new BrowserWindow({
     show: false,
     width: 8000,
     height: 8000,
     webPreferences: {
-      nodeIntegration: true
-    }
+      contextIsolation: false,
+      nodeIntegration: true,
+      enableRemoteModule: true,
+    },
   });
 
-  // Load index.html 
-  win.loadURL('file://' + __dirname + '/index.html');
-
+  // Load index.html
+  win.loadURL("file://" + __dirname + "/index.html");
 }
 
 /**
  * A callback function for the event:
  * When a frame is captured
- * 
+ *
  * @param {Object} event
  * @param {Number} recordIndex
  */
-ipcMain.on('captured', function(event, recordIndex) {
-
+ipcMain.on("captured", function (event, recordIndex) {
   console.log(recordIndex);
-  
 });
 
 /**
@@ -72,8 +70,6 @@ ipcMain.on('captured', function(event, recordIndex) {
  * @param {Object} event
  * @param {String} error
  */
-ipcMain.on('error', function(event, error) {
-
+ipcMain.on("error", function (event, error) {
   process.stderr.write(error);
-  
 });

--- a/render/src/js/app.js
+++ b/render/src/js/app.js
@@ -1,24 +1,24 @@
 /**
  * Terminalizer
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
-var fs                 = require('fs'),
-    path               = require('path'),
-    async              = require('async'),
-    remote             = require('electron').remote,
-    ipcRenderer        = require('electron').ipcRenderer,
-    terminalizerPlayer = require('terminalizer-player');
-var currentWindow      = remote.getCurrentWindow(),
-    capturePage        = currentWindow.webContents.capturePage,
-    step               = remote.getGlobal('step'),
-    renderDir          = remote.getGlobal('renderDir');
+var fs = require("fs"),
+  path = require("path"),
+  async = require("async"),
+  remote = require("electron").remote,
+  ipcRenderer = require("electron").ipcRenderer,
+  terminalizerPlayer = require("terminalizer-player");
+var currentWindow = remote.getCurrentWindow(),
+  capturePage = currentWindow.webContents.capturePage,
+  step = remote.getGlobal("step"),
+  renderDir = remote.getGlobal("renderDir");
 
 // Styles
-import '../css/app.css';
-import 'terminalizer-player/dist/css/terminalizer.min.css';
-import 'xterm/dist/xterm.css';
+import "../css/app.css";
+import "terminalizer-player/dist/css/terminalizer.min.css";
+import "xterm/dist/xterm.css";
 
 /**
  * Used for the step option
@@ -30,84 +30,75 @@ var stepsCounter = 0;
  * A callback function for the event:
  * When the document is loaded
  */
-$(document).ready(function() {
-  
+$(document).ready(function () {
   // Initialize the terminalizer plugin
-  $('#terminal').terminalizer({
-    recordingFile: 'data.json',
+  $("#terminal").terminalizer({
+    recordingFile: "data.json",
     autoplay: true,
-    controls: false
+    controls: false,
   });
 
   /**
    * A callback function for the event:
    * When the terminal playing is started
    */
-  $('#terminal').one('playingStarted', function() {
-
-    var terminalizer = $('#terminal').data('terminalizer');
+  $("#terminal").one("playingStarted", function () {
+    var terminalizer = $("#terminal").data("terminalizer");
 
     // Pause the playing
     terminalizer.pause();
-
   });
 
   /**
    * A callback function for the event:
    * When the terminal playing is paused
    */
-  $('#terminal').one('playingPaused', function() {
-
-    var terminalizer = $('#terminal').data('terminalizer');
+  $("#terminal").one("playingPaused", function () {
+    var terminalizer = $("#terminal").data("terminalizer");
 
     // Reset the terminal
     terminalizer._terminal.reset();
 
-    // When the terminal's reset is done 
-    $('#terminal').one('rendered', render);
-
+    // When the terminal's reset is done
+    $("#terminal").one("rendered", render);
   });
-
 });
 
 /**
  * Render each frame and capture it
  */
 function render() {
-
-  var terminalizer = $('#terminal').data('terminalizer');
+  var terminalizer = $("#terminal").data("terminalizer");
   var framesCount = terminalizer.getFramesCount();
 
   // Foreach frame
-  async.timesSeries(framesCount, function(frameIndex, next) {
+  async.timesSeries(
+    framesCount,
+    function (frameIndex, next) {
+      terminalizer._renderFrame(frameIndex, true, function () {
+        capture(frameIndex, next);
+      });
+    },
+    function (error) {
+      if (error) {
+        throw new Error(error);
+      }
 
-    terminalizer._renderFrame(frameIndex, true, function() {
-      capture(frameIndex, next);
-    });
-
-  }, function(error) {
-
-    if (error) {
-      throw new Error(error);
+      currentWindow.close();
     }
-
-    currentWindow.close();
-    
-  });
-
+  );
 }
 
 /**
  * Capture the current frame
- * 
+ *
  * @param {Number}   frameIndex
  * @param {Function} callback
  */
 function capture(frameIndex, callback) {
-
-  var width = $('#terminal').width();
-  var height = $('#terminal').height();
-  var captureRect = {x: 0, y: 0, width: width, height: height};
+  var width = $("#terminal").width();
+  var height = $("#terminal").height();
+  var captureRect = { x: 0, y: 0, width: width, height: height };
 
   if (stepsCounter != 0) {
     stepsCounter = (stepsCounter + 1) % step;
@@ -116,29 +107,24 @@ function capture(frameIndex, callback) {
 
   stepsCounter = (stepsCounter + 1) % step;
 
-  capturePage(captureRect).then((img) => {
-  
-    var outputPath = path.join(renderDir, frameIndex + '.png');
-  
-    fs.writeFileSync(outputPath, img.toPNG());
-    ipcRenderer.send('captured', frameIndex);
-    callback();
-  
-  }).catch((err) => {
-  
-    throw new err;    
-  
-  });
+  capturePage(captureRect)
+    .then((img) => {
+      var outputPath = path.join(renderDir, frameIndex + ".png");
 
+      fs.writeFileSync(outputPath, img.toPNG());
+      ipcRenderer.send("captured", frameIndex);
+      callback();
+    })
+    .catch((err) => {
+      throw new err();
+    });
 }
 
 /**
  * Catch all unhandled errors
- * 
+ *
  * @param {String} error
  */
-window.onerror = function(error) {
-
-  ipcRenderer.send('error', error);
-
+window.onerror = function (error) {
+  ipcRenderer.send("error", error);
 };

--- a/utility.js
+++ b/utility.js
@@ -1,53 +1,41 @@
 /**
  * Provide utility functions
- * 
+ *
  * @author Mohammad Fares <faressoft.com@gmail.com>
  */
 
 /**
  * Check if a path represents a valid path for a file
- * 
+ *
  * @param  {String}  filePath an absolute or a relative path
  * @return {Boolean}
  */
 function isFile(filePath) {
-
   // Resolve the path into an absolute path
   filePath = di.path.resolve(filePath);
 
   try {
-
     return di.fs.statSync(filePath).isFile();
-
   } catch (error) {
-
     return false;
-
   }
-
 }
 
 /**
  * Check if a path represents a valid path for a directory
- * 
+ *
  * @param  {String}  dirPath an absolute or a relative path
  * @return {Boolean}
  */
 function isDir(dirPath) {
-
   // Resolve the path into an absolute path
   dirPath = di.path.resolve(dirPath);
 
   try {
-
     return di.fs.statSync(dirPath).isDirectory();
-
   } catch (error) {
-
     return false;
-
   }
-
 }
 
 /**
@@ -59,13 +47,12 @@ function isDir(dirPath) {
  * Throws
  * - The provided file doesn't exit
  * - Any reading errors
- * 
+ *
  * @param  {String} filePath  an absolute or a relative path
  * @param  {String} extension
  * @return {String}
  */
 function loadFile(filePath, extension) {
-
   var content = null;
 
   // Resolve the path into an absolute path
@@ -73,7 +60,7 @@ function loadFile(filePath, extension) {
 
   // The file doesn't exist
   if (!isFile(filePath)) {
-    throw new Error('The provided file doesn\'t exit');
+    throw new Error("The provided file doesn't exit");
   }
 
   // Read the file
@@ -84,58 +71,50 @@ function loadFile(filePath, extension) {
   }
 
   return content;
-
 }
 
 /**
  * Check, load, and parse YAML files
  *
  * - Add .yml extension when needed
- * 
+ *
  * Throws
  * - The provided file doesn't exit
  * - The provided file is not a valid YAML file
  * - Any reading errors
- * 
+ *
  * @param  {String} filePath an absolute or a relative path
  * @return {Object}
  */
 function loadYAML(filePath) {
-
-  var file = loadFile(filePath, 'yml');
+  var file = loadFile(filePath, "yml");
 
   // Parse the file
   try {
-
     return {
       json: di.yaml.load(file),
-      raw: file.toString()
+      raw: file.toString(),
     };
-
   } catch (error) {
-
-    throw new Error('The provided file is not a valid YAML file');
-
+    throw new Error("The provided file is not a valid YAML file");
   }
-
 }
 
 /**
  * Check, load, and parse JSON files
  *
  * - Add .json extension when needed
- * 
+ *
  * Throws
  * - The provided file doesn't exit
  * - The provided file is not a valid JSON file
  * - Any reading errors
- * 
+ *
  * @param  {String} filePath an absolute or a relative path
  * @return {Object}
  */
 function loadJSON(filePath) {
-
-  var file = loadFile(filePath, 'json');
+  var file = loadFile(filePath, "json");
 
   // Read the file
   try {
@@ -148,9 +127,8 @@ function loadJSON(filePath) {
   try {
     return JSON.parse(file);
   } catch (error) {
-    throw new Error('The provided file is not a valid JSON file');
+    throw new Error("The provided file is not a valid JSON file");
   }
-
 }
 
 /**
@@ -164,22 +142,20 @@ function loadJSON(filePath) {
  *
  * - Add the extension if not already added
  * - Resolve to `/path/to/FileName.ext`
- * 
+ *
  * @param  {String} filePath  an absolute or a relative path
  * @param  {String} extension
  * @return {String}
  */
 function resolveFilePath(filePath, extension) {
-
   var resolvedPath = di.path.resolve(filePath);
 
   // The extension is not added
-  if (di.path.extname(resolvedPath) != '.' + extension) {
-    resolvedPath += '.' + extension;
+  if (di.path.extname(resolvedPath) != "." + extension) {
+    resolvedPath += "." + extension;
   }
 
   return resolvedPath;
-
 }
 
 /**
@@ -188,120 +164,110 @@ function resolveFilePath(filePath, extension) {
  * - Check if there is a global config file
  *   - Found: Get the global config file
  *   - Not Found: Get the default config file
- * 
+ *
  * @return {Object} {json, raw}
  */
 function getDefaultConfig() {
-
-  var defaultConfigPath = di.path.join(ROOT_PATH, 'config.yml');
-  var globalConfigPath = di.path.join(getGlobalDirectory(), 'config.yml');
+  var defaultConfigPath = di.path.join(ROOT_PATH, "config.yml");
+  var globalConfigPath = di.path.join(getGlobalDirectory(), "config.yml");
 
   // The global config file exists
   if (isFile(globalConfigPath)) {
     return loadYAML(globalConfigPath);
   }
 
-  console.log('defaultConfigPath');
+  console.log("defaultConfigPath");
 
   // Load global config file
   return loadYAML(defaultConfigPath);
-
 }
 
 /**
  * Change a value for a specific key in YAML
- * 
+ *
  * - Works only with the first level keys
  * - Works only with keys with a single value
  * - Apply the changes on the json and raw
  *
- * @param {Object} data  {json, raw} 
+ * @param {Object} data  {json, raw}
  * @param {String} key
  * @param {*}      value
  */
 function changeYAMLValue(data, key, value) {
-
   data.json[key] = value;
-  data.raw = data.raw.replace(new RegExp('^' + key + ':.+$', 'm'), key + ': ' + value);
-
+  data.raw = data.raw.replace(
+    new RegExp("^" + key + ":.+$", "m"),
+    key + ": " + value
+  );
 }
 
 /**
  * Get the path of the global config directory
  *
  * - For Windows, get the path of APPDATA
- * - For Linux and MacOS, get the path of the home directory 
- * 
+ * - For Linux and MacOS, get the path of the home directory
+ *
  * @return {String}
  */
 function getGlobalDirectory() {
-
   // Windows
-  if (typeof process.env.APPDATA != 'undefined') {
-    return di.path.join(process.env.APPDATA, 'terminalizer');
+  if (typeof process.env.APPDATA != "undefined") {
+    return di.path.join(process.env.APPDATA, "terminalizer");
   }
 
-  return di.path.join(process.env.HOME, '.terminalizer');
-
+  return di.path.join(process.env.HOME, ".terminalizer");
 }
 
 /**
  * Check if the global config directory is created
- * 
+ *
  * @return {Boolean}
  */
 function isGlobalDirectoryCreated() {
-
   var globalDirPath = getGlobalDirectory();
 
   return isDir(globalDirPath);
-
 }
 
 /**
  * Generate and save a token to be used for uploading recordings
- * 
+ *
  * @param  {String} token
  * @return {String}
  */
 function generateToken(token) {
-
   var token = di.uuid.v4();
   var globalDirPath = getGlobalDirectory();
-  var tokenPath = di.path.join(globalDirPath, 'token.txt');
+  var tokenPath = di.path.join(globalDirPath, "token.txt");
 
-  di.fs.writeFileSync(tokenPath, token, 'utf8');
+  di.fs.writeFileSync(tokenPath, token, "utf8");
 
   return token;
-
 }
 
 /**
  * Get registered token for uploading recordings
- * 
+ *
  * @return {String|Null}
  */
 function getToken() {
-
   var globalDirPath = getGlobalDirectory();
-  var tokenPath = di.path.join(globalDirPath, 'token.txt');
+  var tokenPath = di.path.join(globalDirPath, "token.txt");
 
   // The file doesn't exist
   if (!isFile(tokenPath)) {
     return null;
   }
 
-  return di.fs.readFileSync(tokenPath, 'utf8');
-
+  return di.fs.readFileSync(tokenPath, "utf8");
 }
 
 /**
  * Remove a registered token
  */
 function removeToken() {
-
   var globalDirPath = getGlobalDirectory();
-  var tokenPath = di.path.join(globalDirPath, 'token.txt');
+  var tokenPath = di.path.join(globalDirPath, "token.txt");
 
   // The file doesn't exist
   if (!isFile(tokenPath)) {
@@ -309,30 +275,24 @@ function removeToken() {
   }
 
   di.fs.unlinkSync(tokenPath);
-
 }
 
 /**
  * Get the name of the current OS
- * 
+ *
  * @return {String} mac, windows, linux
  */
 function getOS() {
-
   // MacOS
-  if (di.os.platform() == 'darwin') {
+  if (di.os.platform() == "darwin") {
+    return "mac";
 
-    return 'mac';
-
-  // Windows
-  } else if (di.os.platform() == 'win32') {
-
-    return 'windows';
-
+    // Windows
+  } else if (di.os.platform() == "win32") {
+    return "windows";
   }
 
-  return 'linux';
-
+  return "linux";
 }
 
 ////////////////////////////////////////////////////
@@ -350,5 +310,5 @@ module.exports = {
   generateToken: generateToken,
   getToken: getToken,
   removeToken: removeToken,
-  getOS: getOS
+  getOS: getOS,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,35 +1,35 @@
-const webpack = require('webpack');
-const path = require('path');
+const webpack = require("webpack");
+const path = require("path");
 
 // Extract CSS into separate files
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CleanWebpackPlugin = require('clean-webpack-plugin');
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const CleanWebpackPlugin = require("clean-webpack-plugin");
 
 // Global variables
 const globals = {
-  $: 'jquery',
-  jQuery: 'jquery',
-  Terminal: ['xterm', 'Terminal'],
-  'window.jQuery': 'jquery',
-  'window.$': 'jquery'
+  $: "jquery",
+  jQuery: "jquery",
+  Terminal: ["xterm", "Terminal"],
+  "window.jQuery": "jquery",
+  "window.$": "jquery",
 };
 
 module.exports = {
-  mode: 'production',
-  target: 'electron-renderer',
+  mode: "production",
+  target: "electron-renderer",
   entry: {
-    app: './render/src/js/app.js'
+    app: "./render/src/js/app.js",
   },
   output: {
-    filename: 'js/[name].js',
-    path: path.resolve(__dirname, 'render/dist'),
-    publicPath: '/dist/'
+    filename: "js/[name].js",
+    path: path.resolve(__dirname, "render/dist"),
+    publicPath: "/dist/",
   },
   plugins: [
-    new CleanWebpackPlugin(['./render/dist'], {verbose: false}),
+    new CleanWebpackPlugin(["./render/dist"], { verbose: false }),
     new webpack.ProvidePlugin(globals),
-    new MiniCssExtractPlugin({filename: 'css/[name].css'}),
-    new webpack.NoEmitOnErrorsPlugin()
+    new MiniCssExtractPlugin({ filename: "css/[name].css" }),
+    new webpack.NoEmitOnErrorsPlugin(),
   ],
   module: {
     rules: [
@@ -37,10 +37,10 @@ module.exports = {
       {
         test: /\.css$/,
         use: [
-          {loader: MiniCssExtractPlugin.loader},
-          {loader: 'css-loader'}
+          { loader: MiniCssExtractPlugin.loader },
+          { loader: "css-loader" },
         ],
-      }
-    ]
-  }
+      },
+    ],
+  },
 };


### PR DESCRIPTION
hello! While trying to make my generated GIFs smaller I ended up prototyping using upng-js to generate an animated PNG instead of a GIF. APNGs are supported by just about everything these days (unlike webp), and embedding seems to work just fine in slack & github, the main places I use terminalizer gifs.

I can't share my original test case for this as it contains stuff that's private to my employer, but file size went from a ~3mb GIF (~2mb when uploaded to gifoptimizer) to ~800kb as a PNG with a 128 colour colourspace.

I can share the following, though, although it is a bit contrived:

![render1607233878178](https://user-images.githubusercontent.com/97317/101273623-5c480c80-37eb-11eb-853a-03cf45efd096.png)

That's a 1.2mb png quantised to 256 colours (unquantised is 4mb). It took ~80s on my 2017 MBP to generate.

The GIF version is 16.2mb and took 12 minutes to generate.

As this is a proof of concept, there's a lot of changes here that I wouldn't normally put in a PR: running `prettier` over the files, not following your coding conventions, upgrading electron. There's also no option to generate a GIF and the quality flag does nothing - it's currently hardcoded in render.js to 256 colors max.

If there's interest in getting this as a feature, let me know how you'd see it working, and I'll see if I can tidy this up.
