### PR TITLE
Ability to explicitly set delay for the very last frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ For Linux and MacOS, the created directory is located under the home directory `
 
 * `frameDelay`: The delay between frames in ms. If the value is `auto` use the actual recording delays.
 * `maxIdleTime`: Maximum delay between frames in ms. Ignored if the `frameDelay` isn't set to `auto`. Set to `auto` to prevent limiting the max idle time.
+* `lastFrameDelay`: Delay for the very last frame in ms. Overrides `maxIdleTime` and `frameDelay` for last frame. If the value is `auto` use the actual recording delay.
 
 ## GIF
 

--- a/commands/play.js
+++ b/commands/play.js
@@ -41,7 +41,8 @@ function command(argv) {
   // Playing options
   var options = {
     frameDelay: argv.recordingFile.json.config.frameDelay,
-    maxIdleTime: argv.recordingFile.json.config.maxIdleTime
+    maxIdleTime: argv.recordingFile.json.config.maxIdleTime,
+    lastFrameDelay: argv.recordingFile.json.config.lastFrameDelay
   };
 
   // Use the actual delays between frames as recorded
@@ -49,7 +50,8 @@ function command(argv) {
 
     options = {
       frameDelay: 'auto',
-      maxIdleTime: 'auto'
+      maxIdleTime: 'auto',
+      lastFrameDelay: 'auto'
     };
 
   }
@@ -105,6 +107,11 @@ function adjustFramesDelays(records, options) {
     options.maxIdleTime = 2000;
   }
 
+  // Default value for options.lastFrameDelay
+  if (typeof options.lastFrameDelay === 'undefined') {
+    options.lastFrameDelay = 'auto';
+  }
+
   // Default value for options.speedFactor
   if (typeof options.speedFactor === 'undefined') {
     options.speedFactor = 1;
@@ -124,6 +131,11 @@ function adjustFramesDelays(records, options) {
     record.delay = record.delay * options.speedFactor;
     
   });
+
+  // Explicitly set lastFrameDelay
+  if (options.lastFrameDelay != 'auto') {
+    records[records.length - 1].delay = options.lastFrameDelay;
+  }
 
 }
 

--- a/commands/render.js
+++ b/commands/render.js
@@ -292,7 +292,8 @@ function command(argv) {
   // For adjusting (calculating) the frames delays
   var adjustFramesDelaysOptions = {
     frameDelay: config.frameDelay,
-    maxIdleTime: config.maxIdleTime
+    maxIdleTime: config.maxIdleTime,
+    lastFrameDelay: config.lastFrameDelay
   };
 
   // For rendering the frames into PNG images

--- a/config.yml
+++ b/config.yml
@@ -41,6 +41,11 @@ frameDelay: auto
 # Set to `auto` to prevent limiting the max idle time
 maxIdleTime: 2000
 
+# Delay for the very last frame in ms
+# Overrides `maxIdleTime` and `frameDelay` value for last frame
+# If the value is `auto` use the actual recording delay
+lastFrameDelay: auto
+
 # The surrounding frame box
 # The `type` can be null, window, floating, or solid`
 # To hide the title use the value null


### PR DESCRIPTION
Addresses #128

This PR adds support for `lastFrameDelay` in `config.yml` to explicitly set delay for the very last frame independently of other delays. This option can be used in conjunction with `frameDelay` to play/render smooth transitions and also at the same time allow the user to witness the output of the recorded command for a while(for example, by setting `lastFrameDelay: 3000`).